### PR TITLE
Set default encoding to UTF-8

### DIFF
--- a/forge/output.py
+++ b/forge/output.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import eventlet, sys
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 re = eventlet.import_patched('re')
 blessed = eventlet.import_patched('blessed')


### PR DESCRIPTION
This fixes issues where Docker builds have unicode characters (emoji, specifically) in their output.