### PR TITLE
Use shallow cloning

### DIFF
--- a/forge/github.py
+++ b/forge/github.py
@@ -87,4 +87,4 @@ class Github(object):
                 raise TaskError(str(result))
 
     def clone(self, url, directory):
-        sh("git", "-c", "core.askpass=true", "clone", inject_token(url, self.token), directory)
+        sh("git", "-c", "core.askpass=true", "clone", "--depth=1", inject_token(url, self.token), directory)

--- a/forge/service.py
+++ b/forge/service.py
@@ -247,7 +247,7 @@ class Service(object):
     @task()
     def pull(self):
         if self.is_git:
-            sh("git", "pull", cwd=self.root)
+            sh("git", "pull", "--update-shallow", cwd=self.root)
 
     def metadata(self, registry, repo):
         metadata = OrderedDict()


### PR DESCRIPTION
We have some big repositories. Forge really only needs the most recent revision when it pulls for itself. This speeds up initial setup for each of our repositories from ~3 minutes to 15 seconds.

Subsequent pulls need to be wary of the fact that they are working from a shallow repository. This could be weird since `forge pull` will pull all repos, including things outside of `.forge`. I don't know what will happen then.