### PR TITLE
Allow --includeIPRanges to be passed to Istio

### DIFF
--- a/docs/docs/reference/istio.md
+++ b/docs/docs/reference/istio.md
@@ -11,7 +11,11 @@ Once Istio is installed, you can use the Istio property in
 
 ```
 name: hello-forge  # name of the service
-istio: true        # when true, apply istioctl kube-inject to all manifests
+istio:
+  enabled: true        # when true, apply istioctl kube-inject to all manifests
+  includeIPRanges:     # optional list of IP ranges in CIDR form to be passed to istioctl kube-inject
+    - 10.0.0.0/8
+    - 172.32.0.0/16
 ...
 ```
 

--- a/forge/core.py
+++ b/forge/core.py
@@ -222,9 +222,12 @@ class Forge(object):
     @task()
     def manifest(self, service):
         k8s_dir, resources = self.template(service)
-        istioify = service.info().get("istio", False)
+        istio_config = service.info().get("istio", {})
+        istioify = istio_config.get("enabled", False)
+        ipranges = istio_config.get("includeIPRanges", None)
+
         if istioify:
-            istio(k8s_dir)
+            istio(k8s_dir, ipranges)
         task.sync()
         self.rendered.append((service, k8s_dir, resources))
         return k8s_dir

--- a/forge/istio.py
+++ b/forge/istio.py
@@ -16,8 +16,13 @@ import os
 from .tasks import task, sh
 
 @task()
-def istio(directory):
+def istio(directory, ipranges=None):
     for name in os.listdir(directory):
-        munged = sh("istioctl", "kube-inject", "-f", os.path.join(directory, name)).output
+        cmd = ["istioctl", "kube-inject", "-f", os.path.join(directory, name)]
+
+        if ipranges is not None:
+            cmd.extend(["--includeIPRanges", ",".join(ipranges)])
+
+        munged = sh(*cmd).output
         with open(os.path.join(directory, name), 'write') as f:
             f.write(munged)

--- a/forge/service_info.py
+++ b/forge/service_info.py
@@ -43,6 +43,15 @@ CONTAINER = Class(
 
 PROFILE = Map(Any())
 
+ISTIO = Class(
+    "istio",
+    """
+    Configures how istioctl kube-inject is called before apllying yaml.
+    """,
+    Field("enabled", Boolean(), default=OMIT, docs="If true run istioctl kube-inject before applying yaml."),
+    Field("includeIPRanges", Sequence(String()), default=OMIT, docs="Comma separated list of IP ranges in CIDR form passed to istioctl kube-inject.")
+)
+
 SERVICE = Class(
     "service.yaml",
     """
@@ -57,7 +66,7 @@ SERVICE = Class(
           docs="A mapping from profile name to profile-specific values."),
     Field("branches", Map(String()), default=OMIT, docs="A mapping from branch pattern to profile name."),
     Field("config", Any(), default=OMIT, docs="Arbitrary application defined configuration parameters for a service."),
-    Field("istio", Boolean(), default=OMIT, docs="If true run istioctl kube-inject before applying yaml."),
+    Field("istio", ISTIO, default=OMIT, docs="Run istioctl kube-inject before applying yaml with the specified settings."),
     strict=False
 )
 

--- a/forge/tests/test_istio.py
+++ b/forge/tests/test_istio.py
@@ -69,4 +69,17 @@ spec:
 def test_isto():
     directory = mktree(YAML)
     istio(directory)
-    print open(os.path.join(directory, "kube.yaml")).read()
+
+    with open(os.path.join(directory, "kube.yaml")) as file:
+        data = file.read()
+
+    assert "sidecar.istio.io/status" in data
+
+def test_include_ip_ranges():
+    directory = mktree(YAML)
+    istio(directory, ["10.0.0.0/8", "172.32.0.0/16"])
+
+    with open(os.path.join(directory, "kube.yaml")) as file:
+        data = file.read()
+
+    assert "- 10.0.0.0/8,172.32.0.0/16" in data

--- a/forge/tests/test_service.py
+++ b/forge/tests/test_service.py
@@ -95,6 +95,20 @@ containers:
    args:
      foo: bar
     """),
+# istio
+    VALID("""
+name: foo,
+istio:
+ enabled: false
+    """),
+    VALID("""
+name: foo,
+istio:
+ enabled: true
+ includeIPRanges:
+  - 10.0.0.0/8
+  - 172.32.0.0/16
+    """)
 )
 
 @pytest.mark.parametrize("error,content", YAML)


### PR DESCRIPTION
Extend the `istio` field in service.yaml to a map, which supports the [--includeIPRanges](https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly) option.