### PR TITLE
Add support for imagebuilder as an alternative builder for docker images

### DIFF
--- a/forge/docker.py
+++ b/forge/docker.py
@@ -37,7 +37,7 @@ class DockerImageBuilder(object):
                 return ["imagebuilder", "-f", dockerfile, "-t", img] + buildargs + [directory]
             return imagebuilder_build
 
-        raise DockerImageBuilderError("No build method named %s exists. Available method names are: %s" % (str, ", ".join(methods)))
+        raise DockerImageBuilderError("No image builder named %s exists. Available builders are: %s" % (str, ", ".join([self.DOCKER, self.IMAGEBUILDER])))
 
 def image(registry, namespace, name, version):
     parts = (registry, namespace, "%s:%s" % (name, version))

--- a/forge/docker.py
+++ b/forge/docker.py
@@ -16,7 +16,7 @@ import base64, boto3, os, urllib2, hashlib
 from tasks import task, TaskError, get, sh, Secret
 
 
-class DockerImageBuilderError(Exception):
+class DockerImageBuilderError(TaskError):
 
     report_traceback = False
     pass

--- a/forge/docker.py
+++ b/forge/docker.py
@@ -15,6 +15,30 @@
 import base64, boto3, os, urllib2, hashlib
 from tasks import task, TaskError, get, sh, Secret
 
+
+class DockerImageBuilderError(Exception):
+
+    report_traceback = False
+    pass
+
+class DockerImageBuilder(object):
+
+    DOCKER = 'docker'
+    IMAGEBUILDER = 'imagebuilder'
+
+    @classmethod
+    def get_cmd_from_name(self, str):
+        if str == self.DOCKER:
+            def docker_build(directory, dockerfile, img, buildargs):
+                return ["docker", "build", directory, "-f", dockerfile, "-t", img] + buildargs
+            return docker_build
+        elif str == self.IMAGEBUILDER:
+            def imagebuilder_build(directory, dockerfile, img, buildargs):
+                return ["imagebuilder", "-f", dockerfile, "-t", img] + buildargs + [directory]
+            return imagebuilder_build
+
+        raise DockerImageBuilderError("No build method named %s exists. Available method names are: %s" % (str, ", ".join(methods)))
+
 def image(registry, namespace, name, version):
     parts = (registry, namespace, "%s:%s" % (name, version))
     return "/".join(p for p in parts if p)
@@ -65,8 +89,10 @@ class DockerBase(object):
         return img
 
     @task()
-    def build(self, directory, dockerfile, name, version, args):
+    def build(self, directory, dockerfile, name, version, args, image_builder=None):
         args = args or {}
+
+        image_builder = image_builder or DockerImageBuilder.DOCKER
 
         buildargs = []
         for k, v in args.items():
@@ -75,7 +101,9 @@ class DockerBase(object):
 
         img = self.image(name, version)
 
-        sh("docker", "build", directory, "-f", dockerfile, "-t", img, *buildargs)
+        cmd = DockerImageBuilder.get_cmd_from_name(image_builder)
+        sh(*cmd(directory, dockerfile, img, buildargs))
+
         return img
 
     def get_changes(self, dockerfile):
@@ -113,7 +141,7 @@ class DockerBase(object):
             yield id, builder_name
 
     @task()
-    def builder(self, directory, dockerfile, name, version, args):
+    def builder(self, directory, dockerfile, name, version, args, image_builder=None):
         # We hash the buildargs and Dockerfile so that we reconstruct
         # the builder container if anything changes. This might want
         # to be extended to cover other files the Dockerfile
@@ -128,7 +156,7 @@ class DockerBase(object):
             else:
                 Builder(self, id).kill()
         if not cid:
-            image = self.build(directory, dockerfile, name, version, args)
+            image = self.build(directory, dockerfile, name, version, args, image_builder=None)
             cid = sh("docker", "run", "--rm", "--name", builder_name, "-dit", "--entrypoint", "/bin/sh",
                      image).output.strip()
         return Builder(self, cid, self.get_changes(dockerfile))

--- a/forge/schema.py
+++ b/forge/schema.py
@@ -584,6 +584,10 @@ def _tag(map):
 def _tag(nd):
     return "map"
 
+@match(Constant)
+def _tag(c):
+    return c.value
+
 class _Signature(object):
 
     def __init__(self, cls, fields):
@@ -687,8 +691,12 @@ class Union(Schema):
             else:
                 raise SchemaError("expecting one of (%s), got %s" % ("|".join(str(s) for s in self.signatures), t))
         if t not in self.tags:
-            raise SchemaError("expecting one of (%s), got %s" % ("|".join(str(s) for s in
-                                                                          self.tags.keys() + self.signatures), t))
+            v = node.value
+            if v not in self.tags:
+                raise SchemaError("expecting one of (%s), got %s(%s)" % ("|".join(str(s) for s in
+                                                                          self.tags.keys() + self.signatures), t, v))
+            return self.tags[v].load(node)
+
         return self.tags[t].load(node)
 
     @property

--- a/forge/schema.py
+++ b/forge/schema.py
@@ -690,12 +690,19 @@ class Union(Schema):
                 return s.load(node)
             else:
                 raise SchemaError("expecting one of (%s), got %s" % ("|".join(str(s) for s in self.signatures), t))
+        # in case this is an union contains constant(s), and t is a 'string' of the value "foo" from the yaml,
+        # the user might have intended a constant named "foo".
         if t not in self.tags:
             v = node.value
-            if v not in self.tags:
-                raise SchemaError("expecting one of (%s), got %s(%s)" % ("|".join(str(s) for s in
+            # `v` could have an unhashable type (like 'list') which results in a type error while the `in` check
+            if (isinstance(v, str) or isinstance(v, unicode)):
+                if v not in self.tags:
+                    raise SchemaError("expecting one of (%s), got %s(%s)" % ("|".join(str(s) for s in
                                                                           self.tags.keys() + self.signatures), t, v))
-            return self.tags[v].load(node)
+                return self.tags[v].load(node)
+            # it doesn't seem like a constant hence not fit within the union
+            raise SchemaError("expecting one of (%s), got %s" % ("|".join(str(s) for s in
+            self.tags.keys() + self.signatures), t))
 
         return self.tags[t].load(node)
 

--- a/forge/service.py
+++ b/forge/service.py
@@ -336,7 +336,7 @@ class Service(object):
                 yield Container(self, c, index=idx)
             else:
                 yield Container(self, c["dockerfile"], c.get("context", None), c.get("args", None),
-                                c.get("rebuild", None), c.get("name", None), index=idx, image_builder=c.get("image_builder"))
+                                c.get("rebuild", None), c.get("name", None), index=idx, image=c.get("image"))
 
     def json(self):
         return {'name': self.name,
@@ -350,7 +350,7 @@ class Service(object):
 
 class Container(object):
 
-    def __init__(self, service, dockerfile, context=None, args=None, rebuild=None, name=None, index=None, image_builder=None):
+    def __init__(self, service, dockerfile, context=None, args=None, rebuild=None, name=None, index=None, image=None):
         self.service = service
         self.dockerfile = dockerfile
         self.context = context or os.path.dirname(self.dockerfile)
@@ -358,7 +358,7 @@ class Container(object):
         self.rebuild_root = rebuild.get("root", "/") if rebuild else None
         self.rebuild_sources = rebuild.get("sources", ()) if rebuild else ()
         self.rebuild_command = rebuild.get("command") if rebuild else None
-        self.image_builder = image_builder
+        self.image_builder = image.get("builder") if image else None
         self.name = name
         self.index = index
 

--- a/forge/service_info.py
+++ b/forge/service_info.py
@@ -39,6 +39,7 @@ CONTAINER = Class(
     Field("name", String(), default=OMIT, docs="The name to use for the container."),
     Field("context", String(), default=OMIT, docs="The build context."),
     Field("args", Map(String("string", "integer", "float")), default=OMIT, docs="Build arguments."),
+    Field("image_builder", String(), default=OMIT, docs="The docker image builder to be used: `docker` for `docker build`, `imagebuilder` for `openshift/imagebuilder`."),
     Field("rebuild", REBUILD, default=OMIT)
 )
 

--- a/forge/service_info.py
+++ b/forge/service_info.py
@@ -30,6 +30,14 @@ REBUILD = Class(
           docs="An array of files or directories that will be copied into the container prior to performing a build.")
 )
 
+IMAGE = Class(
+    "image",
+    """
+    Configures how the container image used to run containers is created.
+    """,
+    Field("builder", Union(Constant("docker"), Constant("imagebuilder")), default=OMIT, docs="The docker image builder to be used: `docker` for `docker build`, `imagebuilder` for `openshift/imagebuilder`."),
+)
+
 CONTAINER = Class(
     "container",
     """
@@ -39,7 +47,7 @@ CONTAINER = Class(
     Field("name", String(), default=OMIT, docs="The name to use for the container."),
     Field("context", String(), default=OMIT, docs="The build context."),
     Field("args", Map(String("string", "integer", "float")), default=OMIT, docs="Build arguments."),
-    Field("image_builder", String(), default=OMIT, docs="The docker image builder to be used: `docker` for `docker build`, `imagebuilder` for `openshift/imagebuilder`."),
+    Field("image", IMAGE, default=OMIT, docs="Configures how the container image used to run this container is created."),
     Field("rebuild", REBUILD, default=OMIT)
 )
 

--- a/forge/tests/test_schema.py
+++ b/forge/tests/test_schema.py
@@ -195,6 +195,12 @@ ABC_FIELDS = Union(Class("a", "a docs", Field("a", Constant("x")), Field("aa", S
                    Class("b", "b docs", Field("b", Constant("x")), Field("bb", String())),
                    Class("c", "c docs", Field("c", Constant("x")), Field("cc", String())))
 
+ABC_STR_CONSTANTS = Union(Integer(),
+                          Float(),
+                          Boolean(),
+                          Class("a", "a docs", Field("a", Constant("y"))),
+                          Constant("b"),
+                          Constant("c"))
 
 UNION_ERRORS = (
     (ABC, "[]", "expecting one of (string|a:map{type=a}|b:map{type=b}|c:map{type=c}"),
@@ -208,6 +214,8 @@ UNION_ERRORS = (
     (ABC_FIELDS, "{}", "expecting one of (a:map{a=x}|b:map{b=x}|c:map{c=x})"),
     (ABC_FIELDS, "{a: []}", "expecting one of (a:map{a=x}|b:map{b=x}|c:map{c=x})"),
     (ABC_FIELDS, "{a: {}}", "expecting one of (a:map{a=x}|b:map{b=x}|c:map{c=x})"),
+    (ABC_STR_CONSTANTS, "{}", "required field 'a' is missing"),
+    (ABC_STR_CONSTANTS, "a", "expecting one of (integer|b|float|bool|c|a:map{a=y}), got string(a)"),
     (Union(String(), Sequence(String())), "foo: bar", "expecting one of (string|sequence), got map")
 )
 

--- a/forge/tests/test_service.py
+++ b/forge/tests/test_service.py
@@ -95,6 +95,26 @@ containers:
    args:
      foo: bar
     """),
+# containers.item.image.builder
+    ERROR("No image builder named %s exists. Available builders are: docker, imagebuilder",
+    """
+name: foo,
+containers:
+ - image:
+     builder: docker
+    """),
+    VALID("""
+name: foo,
+containers:
+ - image:
+     builder: docker
+    """),
+    VALID("""
+name: foo,
+containers:
+ - image:
+     builder: imagebuilder
+    """),
 # istio
     VALID("""
 name: foo,

--- a/forge/tests/test_service.py
+++ b/forge/tests/test_service.py
@@ -96,23 +96,26 @@ containers:
      foo: bar
     """),
 # containers.item.image.builder
-    ERROR("No image builder named %s exists. Available builders are: docker, imagebuilder",
+    ERROR("expecting one of (docker|imagebuilder), got string(foo)",
     """
 name: foo,
 containers:
- - image:
+ - dockerfile: bar
+   image:
+     builder: foo
+    """),
+    VALID("""
+name: foo,
+containers:
+ - dockerfile: bar
+   image:
      builder: docker
     """),
     VALID("""
 name: foo,
 containers:
- - image:
-     builder: docker
-    """),
-    VALID("""
-name: foo,
-containers:
- - image:
+ - dockerfile: bar
+   image:
      builder: imagebuilder
     """),
 # istio


### PR DESCRIPTION
[imagebuilder](github.com/openshift/imagebuilder) is an alternative to `docker build` for building secure(A volume mount inside a build context, no need to leave secrets inside the docker image/metadata in case you have `bundle install` or `npm install` or etc. to install packages hosted in private Git repos) and small docker images(w/ squashing) in a faster way(No context upload).

This adds a imagebuilder support to forge, so that it can leverage imagebuilder for secure, fast, smaller image builds.

## Spec 

A new setting key `image_builder` is added under `containers` in service.yaml, which can be omitted or set to either `docker` or `imagebuilder`.

If the value was omitted or set to `docker`, `docker build` is used for building docker images. This is the existing and default behavior before/after this change.

If the value was set to `imagebuilder`, the `imagebuilder` is used instead.

## Notes

The only gotcha is that to support `--build-arg`s for `imagebuilder`, you need https://github.com/openshift/imagebuilder/pull/58 until it gets merged.