### PR TITLE
Initial commit of SOPS encryption logic

### DIFF
--- a/forge/cli.py
+++ b/forge/cli.py
@@ -31,6 +31,7 @@ import util
 from . import __version__
 from .core import Forge
 from .kubernetes import Kubernetes
+from .sops import edit_secret, view_secret
 from collections import OrderedDict
 
 ENV = find_dotenv(usecwd=True)
@@ -162,6 +163,22 @@ def manifests(forge):
     See `forge build --help` for details on how manifests are built.
     """
     forge.execute(forge.manifest)
+
+@forge.command()
+@click.argument("file_path", required=True, type=click.Path(exists=True))
+def edit(file_path):
+    """
+    Edit a secret file.
+    """
+    edit_secret(file_path) 
+
+@forge.command()
+@click.argument("file_path", required=True, type=click.Path(exists=True))
+def view(file_path):
+    """
+    View a secret file.
+    """
+    view_secret(file_path) 
 
 @forge.command()
 @click.pass_obj

--- a/forge/jinja2.py
+++ b/forge/jinja2.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+from .sops import decrypt, decrypt_cleanup
 from .tasks import task, TaskError
 from jinja2 import Environment, FileSystemLoader, Template, TemplateError, TemplateNotFound, Undefined, UndefinedError
 import os, shutil
@@ -99,6 +100,8 @@ def render(source, target, predicate, **variables):
         for path, dirs, files in os.walk(source):
             for name in files:
                 if not predicate(name): continue
+                if name.endswith("-enc.yaml"):
+                    decrypt(path, name)
                 relpath = os.path.join(os.path.relpath(path, start=source), name)
                 rendered = _do_render(env, root, relpath, variables)
                 outfile = os.path.join(target, relpath)
@@ -107,10 +110,16 @@ def render(source, target, predicate, **variables):
                     os.makedirs(outdir)
                 with open(outfile, "write") as f:
                     f.write(rendered)
+                if name.endswith("-enc.yaml"):
+                    decrypt_cleanup(path, name)
     else:
+        if name.endswith("-enc.yaml"):
+            decrypt(path, name)
         rendered = _do_render(env, root, os.path.basename(source), variables)
         with open(target, "write") as f:
             f.write(rendered)
+        if name.endswith("-enc.yaml"):
+            decrypt_cleanup(path, name)
 
 @task()
 def renders(name, source, **variables):

--- a/forge/sops.py
+++ b/forge/sops.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+import sys
+
+
+def key_check():
+    if not os.getenv('SOPS_KMS_ARN'):
+        sys.exit("You must obtain the master key and export it in the 'SOPS_KMS_ARN' environment variable")
+
+def decrypt(secret_file_dir, secret_file_name):
+    key_check()
+    secret_file_path = os.path.join(secret_file_dir, secret_file_name)
+    temp_secret_file_path = os.path.join(secret_file_dir, "tmp-" + secret_file_name)
+    os.rename(secret_file_path, temp_secret_file_path)
+    with open(secret_file_path, "w") as decrypted_file:
+        subprocess.call(["sops", "-d", temp_secret_file_path], stdout=decrypted_file)
+
+def decrypt_cleanup(secret_file_dir, secret_file_name):
+    secret_file_path = os.path.join(secret_file_dir, secret_file_name)
+    temp_secret_file_path = os.path.join(secret_file_dir, "tmp-" + secret_file_name) 
+    os.remove(secret_file_path)
+    os.rename(temp_secret_file_path, secret_file_path)
+
+def edit_secret(secret_file_path):
+    key_check()
+    subprocess.call(["sops", secret_file_path])
+
+def view_secret(secret_file_path):
+    key_check()
+    subprocess.call(["sops", "-d", secret_file_path])


### PR DESCRIPTION
**Summary:**
I have added the ability to use the forge CLI to view and edit SOPS encrypted secret files in cleartext. In addition, upon `forge deploy`, if there are any files that end in '-enc.yaml' in the 'k8s' directory it will attempt to decrypt the files, base64 encode the secret values, and use for deployment. SOPS is a dependency so perhaps using the python SOPS library is another option, although it is no longer accepting improvements.

Let me know if you have any suggestions or changes or if there are any issues.

**Note:** When deploying, the encrypted files will not be modified, which is ideal if you are using version control to track your SOPS encrypted secret files

**Requirements:**
First, install SOPS: https://github.com/mozilla/sops

You will also need to create or get the SOPS Master Key using AWS KMS, then:

`$ export SOPS_KMS_ARN="your-master-key"`

Verify your AWS credentials are in `~/.aws/credentials`:

```
$ cat ~/.aws/credentials
[default]
aws_access_key_id = AKI.....
aws_secret_access_key = mw......
```

**Usage:**
In addition to normal forge usage, you can:

Edit a SOPS encrypted file in cleartext
`forge edit <path-to-sops-encrypted-file>`
**Note:** If you do not make any changes the encryption/decryption will not affect the file, which is great if you are using version control to track

View a SOPS encrypted file in cleartext
`forge view <path-to-sops-encrypted-file>`

