### PR TITLE
Add --skip-push option to forge build

### DIFF
--- a/forge/cli.py
+++ b/forge/cli.py
@@ -90,7 +90,8 @@ def setup(forge):
 @click.pass_context
 @click.option('-n', '--namespace', envvar='K8S_NAMESPACE', type=click.STRING)
 @click.option('--dry-run', is_flag=True)
-def build(ctx, namespace, dry_run):
+@click.option('--skip-push', is_flag=True, help='Do not push images after they are built.')
+def build(ctx, namespace, dry_run, skip_push):
     """Build deployment artifacts for a service.
 
     Deployment artifacts for a service consist of the docker
@@ -133,6 +134,7 @@ def build(ctx, namespace, dry_run):
     forge = ctx.obj
     forge.namespace = namespace
     forge.dry_run = dry_run
+    forge.skip_push = skip_push
     if ctx.invoked_subcommand is None:
         forge.execute(forge.build)
 

--- a/forge/core.py
+++ b/forge/core.py
@@ -50,6 +50,7 @@ class Forge(object):
         self.scan_base = scan_base
         self.namespace = None
         self.dry_run = False
+        self.skip_push = False
         self.terminal = Terminal()
         self.discovery = Discovery(self)
 
@@ -253,7 +254,8 @@ class Forge(object):
     @task()
     def build(self, service):
         self.bake(service)
-        self.push(service)
+        if not self.skip_push:
+            self.push(service)
         return service, self.manifest(service)
 
     @task()


### PR DESCRIPTION
This option allows skipping the `push` after building images.

Fixes #226 