### PR TITLE
Allow using SOPS with PGP, GCP and Azure

### DIFF
--- a/forge/sops.py
+++ b/forge/sops.py
@@ -22,19 +22,8 @@ def key_check():
             "you must configure Sops using one or more environment variables: %s" % names
         )
 
-def decrypt(secret_file_dir, secret_file_name):
-    secret_file_path = os.path.join(secret_file_dir, secret_file_name)
-    temp_secret_file_path = os.path.join(secret_file_dir, "tmp-" + secret_file_name)
-    os.rename(secret_file_path, temp_secret_file_path)
-    decrypted_content = sh("sops", "--output-type", "binary", "-d", temp_secret_file_path).output
-    with open(secret_file_path, "w") as decrypted_file:
-        decrypted_file.write(decrypted_content)
-
-def decrypt_cleanup(secret_file_dir, secret_file_name):
-    secret_file_path = os.path.join(secret_file_dir, secret_file_name)
-    temp_secret_file_path = os.path.join(secret_file_dir, "tmp-" + secret_file_name) 
-    os.remove(secret_file_path)
-    os.rename(temp_secret_file_path, secret_file_path)
+def decrypt(filename):
+    return sh("sops", "--output-type", "binary", "-d", filename).output
 
 def edit_secret(secret_file_path, create):
     if not os.path.exists(secret_file_path):


### PR DESCRIPTION
Hello. I'd like to use Forge with Sops but the current implementation from #181 is limited AWS KMS-only. So, naturally, I'd like to propose a slight improvement.

This PR improves `key_check` function to look out for PGP, GCP and Azure environment variables, not just AWS.

Also, key checks are removed for decryption (and re-encryption) operations. Sops is smart enough to figure the keys on its own: the encrypted files actually contain all the necessary information. At the very least, just running `sops -d example-enc.yml` without any environment variables set is enough to decrypt it, as long as I have the keys, of course.

I've tested my changes and they seem to work with my PGP+GCP KMS Sops-encrypted files without any issues.

Thanks!