### PR TITLE
Fix for missing namespace on delete

### DIFF
--- a/forge/kubernetes.py
+++ b/forge/kubernetes.py
@@ -247,16 +247,18 @@ class Kubernetes(object):
     def delete(self, labels):
         # never try to delete namespaces or storage classes because they are shared resources
         all = ",".join(r for r in ALL if r not in ('ns', 'sc'))
-        lines = sh("kubectl", "get", all, '--all-namespaces', selector(labels), '-ogo-template={{range .items}}{{.kind}} {{.metadata.namespace}} {{.metadata.name}}{{"\\n"}}{{end}}').output.splitlines()
+        lines = sh("kubectl", "get", all, '--all-namespaces', selector(labels), '-ogo-template={{range .items}}{{.kind}},{{.metadata.namespace}},{{.metadata.name}}{{"\\n"}}{{end}}').output.splitlines()
 
         byns = {}
         for line in lines:
-            parts = line.split()
+            parts = line.split(',')
             if len(parts) == 2:
                 kind, name = parts
                 namespace = None
             else:
                 kind, namespace, name = parts
+                if namespace == '<no value>':
+                    namespace = None
             if namespace not in byns:
                 byns[namespace] = []
             byns[namespace].append((kind, name))


### PR DESCRIPTION
If objects created by Forge have no namespace assigned Forge crashes on delete.

Eg.:
```
$ forge delete --all
║ kubectl get csr,clusterrolebindings,clusterroles,cm,controllerrevisions,crd,ds,deploy,ep,ev,hpa,ing,jobs,limits,netpol,no,pvc,pv,pdb,po,psp,podtemplates,rs,rc,quota,rolebindings,roles,secrets,sa,svc,sts --all-namespaces -lforge.service -ogo-template={{range .items}}{{.kind}} {{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}
║ ClusterRoleBinding <no value> efs-provisioner
║ ClusterRole <no value> efs-provisioner
║ Deployment default efs-provisioner
║ ServiceAccount default efs-provisioner
Traceback (most recent call last):
  File "/usr/local/bin/forge/.bootstrap/_pex/pex.py", line 367, in execute
  File "/usr/local/bin/forge/.bootstrap/_pex/pex.py", line 293, in _wrap_coverage
  File "/usr/local/bin/forge/.bootstrap/_pex/pex.py", line 325, in _wrap_profiling
  File "/usr/local/bin/forge/.bootstrap/_pex/pex.py", line 410, in _execute
  File "/usr/local/bin/forge/.bootstrap/_pex/pex.py", line 468, in execute_entry
  File "/usr/local/bin/forge/.bootstrap/_pex/pex.py", line 486, in execute_pkg_resources
  File "/Users/nuada/.pex/install/Forge-0.4.15-py2-none-any.whl.9231fb8ee2b34ba80e2fa9fab3e8592e4ca4ae54/Forge-0.4.15-py2-none-any.whl/forge/cli.py", line 370, in call_main
    exit(forge())
  File "/Users/nuada/.pex/install/click-6.7-py2.py3-none-any.whl.6d9ff910081ac14222b6215822bc2664662de745/click-6.7-py2.py3-none-any.whl/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/nuada/.pex/install/click-6.7-py2.py3-none-any.whl.6d9ff910081ac14222b6215822bc2664662de745/click-6.7-py2.py3-none-any.whl/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/nuada/.pex/install/click-6.7-py2.py3-none-any.whl.6d9ff910081ac14222b6215822bc2664662de745/click-6.7-py2.py3-none-any.whl/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/nuada/.pex/install/click-6.7-py2.py3-none-any.whl.6d9ff910081ac14222b6215822bc2664662de745/click-6.7-py2.py3-none-any.whl/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/nuada/.pex/install/click-6.7-py2.py3-none-any.whl.6d9ff910081ac14222b6215822bc2664662de745/click-6.7-py2.py3-none-any.whl/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/nuada/.pex/install/click-6.7-py2.py3-none-any.whl.6d9ff910081ac14222b6215822bc2664662de745/click-6.7-py2.py3-none-any.whl/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/nuada/.pex/install/Forge-0.4.15-py2-none-any.whl.9231fb8ee2b34ba80e2fa9fab3e8592e4ca4ae54/Forge-0.4.15-py2-none-any.whl/forge/tasks.py", line 252, in __call__
    return result.get()
  File "/Users/nuada/.pex/install/Forge-0.4.15-py2-none-any.whl.9231fb8ee2b34ba80e2fa9fab3e8592e4ca4ae54/Forge-0.4.15-py2-none-any.whl/forge/executor.py", line 409, in do_run
    result.value = fun(*args, **kwargs)
  File "/Users/nuada/.pex/install/Forge-0.4.15-py2-none-any.whl.9231fb8ee2b34ba80e2fa9fab3e8592e4ca4ae54/Forge-0.4.15-py2-none-any.whl/forge/cli.py", line 365, in delete
    kube.delete(labels)
  File "/Users/nuada/.pex/install/Forge-0.4.15-py2-none-any.whl.9231fb8ee2b34ba80e2fa9fab3e8592e4ca4ae54/Forge-0.4.15-py2-none-any.whl/forge/tasks.py", line 252, in __call__
    return result.get()
  File "/Users/nuada/.pex/install/Forge-0.4.15-py2-none-any.whl.9231fb8ee2b34ba80e2fa9fab3e8592e4ca4ae54/Forge-0.4.15-py2-none-any.whl/forge/executor.py", line 409, in do_run
    result.value = fun(*args, **kwargs)
  File "/Users/nuada/.pex/install/Forge-0.4.15-py2-none-any.whl.9231fb8ee2b34ba80e2fa9fab3e8592e4ca4ae54/Forge-0.4.15-py2-none-any.whl/forge/kubernetes.py", line 259, in delete
    kind, namespace, name = parts
ValueError: too many values to unpack
```